### PR TITLE
Add missing JS bootstrap-sprockets

### DIFF
--- a/app/assets/javascripts/assets/common.js
+++ b/app/assets/javascripts/assets/common.js
@@ -7,5 +7,6 @@
 //= require_tree .
 //= require jquery
 //= require jquery_ujs
+//= require bootstrap-sprockets
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap


### PR DESCRIPTION
+ Add missing JS bootstrap-sprockets
(https://github.com/twbs/bootstrap-sass)
+ I found this issue when testing this PR: https://github.com/killbill/killbill-payment-test-ui/pull/7
The data-toggle didn't work cause of missing BootstrapJS