### PR TITLE
fix: correct border-color syntax for .btn-primary class

### DIFF
--- a/app/assets/stylesheets/assets/theme.css
+++ b/app/assets/stylesheets/assets/theme.css
@@ -13,7 +13,7 @@
 
 .btn-primary {
   background-color: #1570ef !important;
-  border-color: ##1570ef !important;
+  border-color: #1570ef !important;
 }
 
 .text-primary {


### PR DESCRIPTION
This PR fixes comments on following PR: https://github.com/killbill/killbill-assets-ui/pull/16